### PR TITLE
[PROD-4142] Remove enumOptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vjsf",
-  "version": "0.10.3",
+  "version": "0.11.0",
   "description": "Vue-component capable of building HTML forms out of a JSON schema. A port of react-jsonschema-form",
   "main": "dist/vjsf.umd.min.js",
   "scripts": {

--- a/src/components/fields/ArrayField.MultiSelect.vue
+++ b/src/components/fields/ArrayField.MultiSelect.vue
@@ -22,7 +22,7 @@
 </template>
 
 <script>
-import { getWidget, getUiOptions, optionsList } from '../../utils';
+import { getWidget, getUiOptions } from '../../utils';
 
 const PROPS = {
   label: String,
@@ -56,11 +56,7 @@ export default {
     },
     widgetWithOptions() {
       const itemsSchema = this.schema.items;
-      const enumOptions = optionsList(itemsSchema);
-      const { widget = 'select', ...options } = {
-        ...getUiOptions(this.uiSchema),
-        enumOptions
-      };
+      const { widget = 'select', ...options } = getUiOptions(this.uiSchema);
       return { widget, options };
     },
     errorsMessages() {

--- a/src/components/fields/BooleanField.vue
+++ b/src/components/fields/BooleanField.vue
@@ -20,7 +20,7 @@
 </template>
 
 <script>
-import { getWidget, getUiOptions, optionsList } from '../../utils';
+import { getWidget, getUiOptions } from '../../utils';
 
 const PROPS = {
   name: String,
@@ -50,21 +50,13 @@ export default {
   inject: ['setFormDataByPointer'],
   props: PROPS,
   computed: {
-    enumOptions() {
-      return optionsList({
-        enum: this.schema.enum || [true, false],
-        enumNames:
-          this.schema.enumNames ||
-          (this.schema.enum && this.schema.enum[0] === false ? ['no', 'yes'] : ['yes', 'no'])
-      });
-    },
     widgetWithOptions() {
       const { widgets } = this.registry;
       // eslint-disable-next-line no-unused-vars
       const { widget = 'checkbox', placeholder, ...options } = getUiOptions(this.uiSchema);
       return {
         widget: getWidget(this.schema, widget, widgets),
-        options: { ...options, enumOptions: this.enumOptions }
+        options
       };
     },
     errorsMessages() {

--- a/src/components/fields/StringField.vue
+++ b/src/components/fields/StringField.vue
@@ -21,7 +21,7 @@
 </template>
 
 <script>
-import { getWidget, getUiOptions, isSelect, optionsList, hasWidget } from '../../utils';
+import { getWidget, getUiOptions, isSelect, hasWidget } from '../../utils';
 
 const PROPS = {
   schema: Object,
@@ -54,13 +54,10 @@ export default {
     resolvedSchema() {
       return this.resolveSchemaShallowly(this.schema, this.formData);
     },
-    enumOptions() {
-      return isSelect(this.resolvedSchema) && optionsList(this.resolvedSchema);
-    },
     widgetCls() {
       const { format } = this.resolvedSchema;
       const { widgets } = this.registry;
-      let defaultWidget = this.enumOptions ? 'select' : 'text';
+      let defaultWidget = this.resolvedSchema.enum ? 'select' : 'text';
       if (format && hasWidget(this.resolvedSchema, format, widgets)) {
         defaultWidget = format;
       }
@@ -75,7 +72,7 @@ export default {
         placeholder,
         ...options
       } = getUiOptions(this.uiSchema);
-      return { ...options, enumOptions: this.enumOptions };
+      return options;
     },
     placeholder() {
       return getUiOptions(this.uiSchema).placeholder || '';

--- a/src/components/widgets/CheckboxesWidget.vue
+++ b/src/components/widgets/CheckboxesWidget.vue
@@ -12,6 +12,7 @@ function deselectValue(value, selected) {
 }
 
 const PROPS = {
+  schema: Object,
   id: String,
   autofocus: { default: false },
   options: { default: () => ({ inline: false }) },
@@ -22,28 +23,26 @@ export default {
   props: PROPS,
   methods: {
     isDisabled(option) {
-      const itemDisabled =
-        this.options.enumDisabled && this.options.enumDisabled.indexOf(option.value) != -1;
-      return this.disabled || this.readonly || itemDisabled;
+      return this.disabled || this.readonly;
     },
     isChecked(option) {
-      return this.value.indexOf(option.value) !== -1;
+      return this.value.indexOf(option) !== -1;
     }
   },
 
   render(h) {
     const { id, options, value, autofocus } = this.$props;
-    const { enumOptions, inline } = options;
+    const { inline } = options;
 
     const makeCheckbox = ({ index, option }) =>
       h('span', {}, [
         h('input', {
           on: {
             change: (event) => {
-              const all = enumOptions.map(({ value }) => value);
+              const all = this.schema.enum;
               const changeValue = event.target.checked
-                ? selectValue(option.value, value, all)
-                : deselectValue(option.value, value);
+                ? selectValue(option, value, all)
+                : deselectValue(option, value);
 
               this.$emit('change', changeValue);
             }
@@ -60,13 +59,12 @@ export default {
       ]);
 
     return h('div', { attrs: { id } }, [
-      ...enumOptions.map((option, index) => {
-        const disabledCls = this.isDisabled(option) ? 'disabled' : '';
+      ...this.schema.enum.map((option, index) => {
 
         const checkbox = [makeCheckbox({ option, index })];
         const attrs = inline
-          ? { class: `checkbox-inline ${disabledCls}` }
-          : { class: `checkbox ${disabledCls}` };
+          ? { class: `checkbox-inline` }
+          : { class: `checkbox` };
 
         return inline
           ? h('label', { key: index, attrs }, checkbox)

--- a/src/components/widgets/RadioWidget.vue
+++ b/src/components/widgets/RadioWidget.vue
@@ -13,18 +13,16 @@ export default {
   props: PROPS,
   methods: {
     isDisabled(option) {
-      const itemDisabled =
-        this.options.enumDisabled && this.options.enumDisabled.indexOf(option.value) != -1;
-      return this.disabled || this.readonly || itemDisabled;
+      return this.disabled || this.readonly;
     },
     isChecked(option) {
-      return this.value === option.value;
+      return this.value === option;
     }
   },
 
   render(h) {
     const { id, options, autofocus } = this.$props;
-    const { enumOptions, inline } = options;
+    const { inline } = options;
     const name = Math.random().toString();
 
     const makeRadio = ({ index, option }) =>
@@ -32,7 +30,7 @@ export default {
         h('input', {
           on: {
             ...this.$listeners,
-            change: () => this.$emit('change', option.value)
+            change: () => this.$emit('change', option)
           },
           attrs: {
             type: 'radio',
@@ -41,20 +39,18 @@ export default {
             disabled: this.isDisabled(option),
             required: this.required,
             autofocus: autofocus && index === 0,
-            value: option.value
+            value: option
           }
         }),
-        h('span', {}, [option.label])
+        h('span', {}, [option])
       ]);
 
     return h('div', { attrs: { id } }, [
-      ...enumOptions.map((option, index) => {
-        const disabledCls = this.isDisabled(option) ? 'disabled' : '';
-
+      ...this.schema.enum.map((option, index) => {
         const checkbox = [makeRadio({ option, index })];
         const attrs = inline
-          ? { class: `radio-inline ${disabledCls}` }
-          : { class: `radio ${disabledCls}` };
+          ? { class: `radio-inline` }
+          : { class: `radio` };
 
         return inline
           ? h('label', { key: index, attrs }, checkbox)

--- a/src/components/widgets/SelectWidget.vue
+++ b/src/components/widgets/SelectWidget.vue
@@ -16,12 +16,11 @@
       {{ placeholder }}
     </option>
     <option
-      v-for="(enumOption, index) in enumOptions"
+      v-for="(option, index) in enumOptions"
       :key="index"
-      :disabled="isOptionDisabled(enumOption.value)"
-      :value="enumOption.value"
+      :value="option"
     >
-      {{ enumOption.label }}
+      {{ option }}
     </option>
   </select>
 </template>

--- a/src/utils.js
+++ b/src/utils.js
@@ -258,16 +258,6 @@ export function allowAdditionalItems(schema) {
   return isObject(schema.additionalItems);
 }
 
-export function optionsList(schema) {
-  if (schema.enum) {
-    return schema.enum.map((value, i) => {
-      const label = (schema.enumNames && schema.enumNames[i]) || String(value);
-      return { label, value };
-    });
-  }
-  return [];
-}
-
 // In the case where we have to implicitly create a schema, it is useful to know what type to use
 //  based on the data we are defining
 export const guessType = function guessType(value) {


### PR DESCRIPTION
Дропнул формирование лейблов из базовой либы, т.к. они главным образом должны получаться из переводов (а либа про них не в курсе особо), так же в либе была логика формирования лейблов из `enumNames` в схеме, что неособо корректно, т.к. не соответствует спецификации `JSONSchema`

Также дропнул логику дизабельности отдельных пунктов - не используется в ХФ (во всяком случае пока)