### PR TITLE
[SRV-23063] Support external errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vjsf",
-  "version": "0.12.2",
+  "version": "0.13.0",
   "description": "Vue-component capable of building HTML forms out of a JSON schema. A port of react-jsonschema-form",
   "main": "dist/vjsf.umd.min.js",
   "scripts": {

--- a/src/components/fields/ArrayField.FixedArray.vue
+++ b/src/components/fields/ArrayField.FixedArray.vue
@@ -40,7 +40,7 @@
       :item-schema="getItemSchema(keyedItem.item, index)"
       :item-ui-schema="getItemUiSchema(index)"
       :item-data="keyedItem.item"
-      :errors="errors[index]"
+      :error-schema="(errorSchema || [])[index]"
       :autofocus="autofocus && index === 0"
       v-on="arrayFieldItemEventListeners"
     />
@@ -59,7 +59,7 @@ const PROPS = {
   keyedFormData: Array,
   schema: Object,
   uiSchema: {},
-  errors: { type: Array, default: () => [] },
+  errorSchema: { type: Array, default: () => [] },
   id: String,
   pointer: {
     type: String,

--- a/src/components/fields/ArrayField.Item.vue
+++ b/src/components/fields/ArrayField.Item.vue
@@ -21,7 +21,7 @@
       :form-data="itemData"
       :schema="resolvedSchema"
       :ui-schema="itemUiSchema"
-      :errors="errors"
+      :error-schema="errorSchema"
       :required="isRequired"
       :registry="registry"
       :disabled="disabled"
@@ -50,7 +50,7 @@ const PROPS = {
     type: String,
     required: true
   },
-  errors: Object,
+  errorSchema: Object,
   uiSchema: { type: Object },
   registry: { type: Object, required: true },
   autofocus: { type: Boolean, default: false },

--- a/src/components/fields/ArrayField.NormalArray.vue
+++ b/src/components/fields/ArrayField.NormalArray.vue
@@ -15,7 +15,7 @@
     :label="label"
     :description="description"
     :autofocus="autofocus"
-    :raw-error-infos="errors"
+    :error-schema="errorSchema"
     :pointer="pointer"
     v-on="$listeners"
   />
@@ -29,7 +29,7 @@
     :readonly="readonly"
     :required="required"
     :registry="registry"
-    :raw-error-infos="errors"
+    :error-schema="errorSchema"
     :pointer="pointer"
     :schema="schema"
     :ui-schema="uiSchema"
@@ -68,7 +68,7 @@
       :ui-schema="uiSchema"
       :item-schema="schema.items"
       :item-ui-schema="uiSchema.items"
-      :errors="errors[index]"
+      :error-schema="(errorSchema || [])[index]"
       :item-data="keyedItem.item"
       :autofocus="autofocus && index === 0"
       v-on="arrayFieldItemEvents"
@@ -99,7 +99,7 @@ const PROPS = {
   keyedFormData: Array,
   schema: Object,
   uiSchema: Object,
-  errors: { type: Array, default: () => [] },
+  errorSchema: { type: Array, default: () => [] },
   registry: { type: Object, required: true },
   autofocus: { type: Boolean, default: false },
   required: { type: Boolean, default: false },

--- a/src/components/fields/ArrayField.vue
+++ b/src/components/fields/ArrayField.vue
@@ -9,7 +9,7 @@
     :keyed-form-data="keyedFormData"
     :schema="resolvedSchema"
     :ui-schema="uiSchema"
-    :errors="errors"
+    :error-schema="errorSchema"
     :name="name"
     :required="required"
     :disabled="disabled"
@@ -32,7 +32,7 @@
     :keyed-form-data="keyedFormData"
     :schema="resolvedSchema"
     :ui-schema="uiSchema"
-    :errors="errors"
+    :error-schema="errorSchema"
     :name="name"
     :required="required"
     :disabled="disabled"
@@ -69,7 +69,7 @@ const PROPS = {
   },
   uiSchema: { type: Object, default: () => ({}) },
   schema: Object,
-  errors: { type: Array, default: () => [] },
+  errorSchema: { type: Array, default: () => [] },
   registry: { type: Object, required: true },
   required: { type: Boolean, default: false },
   disabled: { type: Boolean, default: false },

--- a/src/components/fields/BooleanField.vue
+++ b/src/components/fields/BooleanField.vue
@@ -11,8 +11,7 @@
     :readonly="readonly"
     :autofocus="autofocus"
     :registry="registry"
-    :raw-errors="errorsMessages"
-    :raw-error-infos="errors"
+    :error-schema="errorSchema"
     :pointer="pointer"
     v-on="$listeners"
     @change="handleChange"
@@ -34,7 +33,7 @@ const PROPS = {
     required: true
   },
   formData: Boolean,
-  errors: {
+  errorSchema: {
     type: Array,
     default: () => []
   },
@@ -58,10 +57,6 @@ export default {
         widget: getWidget(this.schema, widget, widgets),
         options
       };
-    },
-    errorsMessages() {
-      // TODO: кажется что дропнуть, толку в этом мало, но мало ли где-то используются чисто текста, для мажорной версии
-      return this.errors.map(({ message }) => message);
     }
   },
   methods: {

--- a/src/components/fields/NumberField.vue
+++ b/src/components/fields/NumberField.vue
@@ -25,7 +25,7 @@ const PROPS = {
   readonly: { type: Boolean, default: false },
   autofocus: { type: Boolean, default: false },
   registry: { type: Object, required: true },
-  errors: { type: Array, default: () => [] }
+  errorSchema: { type: Array, default: () => [] }
 };
 
 export default {

--- a/src/components/fields/ObjectField.vue
+++ b/src/components/fields/ObjectField.vue
@@ -26,7 +26,7 @@
         :required="isRequired(propName)"
         :schema="resolvedSchema.properties[propName]"
         :ui-schema="scopedProps.uiSchema || uiSchema[propName]"
-        :errors="errors[propName]"
+        :error-schema="(errorSchema || {})[propName]"
         :registry="registry"
         :disabled="disabled"
         :readonly="readonly"
@@ -56,7 +56,7 @@ const PROPS = {
     type: Object,
     required: true
   },
-  errors: { type: Object, default: () => ({}) },
+  errorSchema: { type: Object, default: () => ({}) },
   schema: Object,
   registry: { type: Object, required: true },
   disabled: { type: Boolean, default: false },

--- a/src/components/fields/SchemaField.vue
+++ b/src/components/fields/SchemaField.vue
@@ -13,7 +13,7 @@
     :ui-schema="uiSchema"
     :form-data="formData"
     :pointer="pointer"
-    :errors="errors"
+    :error-schema="errorSchema"
   >
     <component
       :is="fieldCls"
@@ -25,7 +25,7 @@
       :description="description"
       :autofocus="hasAutofocus"
       :disabled="isDisabled"
-      :errors="errors"
+      :error-schema="errorSchema"
       :readonly="isReadOnly"
       :registry="registry"
       :required="required"
@@ -55,7 +55,7 @@ const PROPS = {
   },
   schema: Object,
   uiSchema: { type: Object, default: () => ({}) },
-  errors: { type: [Array, Object] },
+  errorSchema: { type: [Array, Object] },
   registry: { type: Object, required: true },
   disabled: Boolean,
   required: Boolean,

--- a/src/components/fields/StringField.vue
+++ b/src/components/fields/StringField.vue
@@ -13,8 +13,7 @@
     :autofocus="autofocus"
     :registry="registry"
     :placeholder="placeholder"
-    :raw-errors="errorsMessages"
-    :raw-error-infos="errors"
+    :error-schema="errorSchema"
     :pointer="pointer"
     @change="handleChange"
   />
@@ -39,7 +38,7 @@ const PROPS = {
     default: undefined
   },
   registry: { type: Object, required: true },
-  errors: { type: Array, default: () => [] },
+  errorSchema: { type: Array, default: () => [] },
   required: { type: Boolean, default: false },
   disabled: { type: Boolean, default: false },
   readonly: { type: Boolean, default: false },
@@ -76,10 +75,6 @@ export default {
     },
     placeholder() {
       return getUiOptions(this.uiSchema).placeholder || '';
-    },
-    errorsMessages() {
-      // TODO: кажется что дропнуть, толку в этом мало, но мало ли где-то используются чисто текста, для мажорной версии
-      return this.errors.map(({ message }) => message);
     }
   },
   methods: {

--- a/src/components/form-props.js
+++ b/src/components/form-props.js
@@ -28,5 +28,6 @@ export const PROPS = {
   omitMissingFields: { type: Boolean, default: false },
   customFormats: { type: Object, default: () => ({}) },
   fieldsSelector: { type: String, default: '[name]' },
-  invalidFieldsSelector: { type: String, default: '[name][aria-invalid="true"]' }
+  invalidFieldsSelector: { type: String, default: '[name][aria-invalid="true"]' },
+  errorSchema: { type: Object, default: undefined }
 };


### PR DESCRIPTION
**Что сделано**
- Отображение ошибок пришедших снаружи
- Переименования (раньше одно и то же называлось `errorSchema`, `raw-error-infos` или `errors` в зависимости от контекста)

Изменения в констексте [задачи](https://huntflow.atlassian.net/browse/SRV-23063)
https://github.com/huntflow/huntflow/pull/15435