### PR TITLE
[SRV-23621] Drop falsy values

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vjsf",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "description": "Vue-component capable of building HTML forms out of a JSON schema. A port of react-jsonschema-form",
   "main": "./dist/vjsf.es.js",
   "scripts": {

--- a/src/components/_Form.vue
+++ b/src/components/_Form.vue
@@ -187,16 +187,25 @@ export default {
       }
       return undefined;
     },
-    setFormDataByPointer(pointer, value) {
+    setFormDataByPointer(pointer, value, options) {
       const paths = jsonPointer.parse(pointer);
       const last = paths.pop();
 
       const formData = this.getFormDataByPath(jsonPointer.compile(paths));
+      const isPrimitive =
+        options?.schema.type === 'string' ||
+        options.schema.type === 'number' ||
+        options.schema.type === 'integer';
+      const shouldRemove = isPrimitive && options?.required === false && !value && value !== 0;
       if (typeof value === 'function') {
         // Для производительных действий над массивами: удаление/добавление/перемещение
         value(this.getFormDataByPath(pointer));
       } else {
-        formData[last] = value;
+        if (shouldRemove) {
+          delete formData[last];
+        } else {
+          formData[last] = value;
+        }
       }
       this.$emit('change', this.formDataState);
       if (this.mustValidate) {

--- a/src/components/fields/BooleanField.vue
+++ b/src/components/fields/BooleanField.vue
@@ -63,7 +63,10 @@ export default {
   },
   methods: {
     handleChange(value) {
-      this.setFormDataByPointer(this.pointer, value);
+      this.setFormDataByPointer(this.pointer, value, {
+        required: this.required,
+        schema: this.schema
+      });
     }
   }
 };

--- a/src/components/fields/StringField.vue
+++ b/src/components/fields/StringField.vue
@@ -82,7 +82,10 @@ export default {
   },
   methods: {
     handleChange(value) {
-      this.setFormDataByPointer(this.pointer, value);
+      this.setFormDataByPointer(this.pointer, value, {
+        required: this.required,
+        schema: this.schema
+      });
     }
   }
 };


### PR DESCRIPTION
https://huntflow.atlassian.net/browse/SRV-23621

До этих измений при сбросе на пустое значение на бэк отправлялось null-значение. Это где-то работает, где-то нет. 
Работает напр. на формах из схема-конвертера, т.к. конвертер дополнительно проставляет таким полям свойство `nullable: true` 
А на Ф.О.С. не работает, так как они хранятся AS IS и доп. свойства на их поля не навяливаются.
Ввиду чего такие поля (пустые и не-обязательные) нужно вообще выкидавать 